### PR TITLE
Add concurrent-ruby runtime dependency

### DIFF
--- a/simple_ext.gemspec
+++ b/simple_ext.gemspec
@@ -10,4 +10,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.0'
   spec.files         = Dir['lib/**/*.rb']
+  spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
 end


### PR DESCRIPTION
Added runtime dependency for concurrent-ruby gem as it is used here - 
https://github.com/kumartushar/simple_ext/blob/master/lib/simple_ext/object/blank.rb#L2